### PR TITLE
Add finite state machine to game logic.

### DIFF
--- a/Character.js
+++ b/Character.js
@@ -55,9 +55,6 @@ Character.prototype.levelUp = function() {
     }
 
     this.nextLevelAt = Math.floor(this.nextLevelAt + (this.nextLevelAt * 2) - (this.level * 50));
-    
-    console.log(`You are now level ${this.level}! Your now have ${this.profession.health} health and ${this.profession.attack} attack.`);
-    console.log(`Reach the next level at ${this.nextLevelAt} XP!`);
 }
 
 /**

--- a/Game.js
+++ b/Game.js
@@ -1,213 +1,347 @@
 const events = require('events');
+const Machine = require('xstate').Machine;
+const assign = require('xstate').assign;
+const interpret = require('xstate').interpret;
 const Character = require('./Character');
 const ActionTypes = require('./ActionTypes');
 const EventTypes = require("./EventTypes");
 const SentimentTypes = require("./SentimentTypes");
 
+let machine;
+let game;
+let gameService;
+
 class Game extends events.EventEmitter {
-    constructor() {
-        super();
-        this.state = null;
-    }
-
-    setState(state) {
-        if (!state) return;
-
-        this.state = state;
-        this.state.character = new Character(
-            state.character.name,
-            state.character.profession.profession,
-            state.character.gold,
-            state.character.profession.health,
-            state.character.attack,
-            state.character.level,
-            state.character.xp,
-            state.character.nextLevelAt
-        );
-    }
 
     start() {
-        this.emit(EventTypes.MESSAGE, { key: 'game.name' });
-
-        if (!this.state) {
-            return this.createCharacter()
-        }
-        this.emit(EventTypes.MESSAGE, {
-            key: 'welcome.returning',
-            meta: { name: this.state.character.name },
-            sentiment: SentimentTypes.POSITIVE
-        });
-        this.emit(EventTypes.PROMPTS, [
-            {
-                key: 'main',
-                type: 'list',
-                choices: [
-                    ActionTypes.FIGHT_ENEMY,
-                    ActionTypes.REST,
-                    ActionTypes.VIEW_CHARACTER
-                ]
-            }
-        ]);
-
-        // Listen for the response to come in once.
-        this.once(EventTypes.PROMPT_RESPONSE, ([{ main }]) => {
-            switch(main) {
-                case ActionTypes.FIGHT_ENEMY:
-                    return this.attack();
-                case ActionTypes.REST:
-                    return this.rest();
-                case ActionTypes.VIEW_CHARACTER:
-                    return this.viewCharacter();
-                default:
-                    throw new Error("Action not yet implemented.");
-            }
-        });
+        if (gameService) return;
+        gameService = interpret(machine)
+            // .onTransition(state => console.log(state.value))
+            .start();
     }
-
-    // randomly select an enemy type
-    // fighting is health - attack, repeat until player or enemy health <= 0
-    // award gold based on enemy strength
-    attack() {
-        // Make a clone of the current state which we'll emit at the end of the action.
-        const state = Object.assign({}, this.state);
-
-        // Naive enemy implementation...
-        const damage = Math.floor(Math.random() * 10 + 1); // 1 - 10 damage
-        const health = Math.floor(Math.random() * 10 + 21); // 10 - 30 health
-        const gold = health + damage;
-        const xp = health;
-        
-        const enemy = { damage, health, gold, xp };
-
-        while (state.character.profession.health > 0 && enemy.health > 0) {
-            const prevEnemyHealth = enemy.health;
-            
-            state.character.doDamage(enemy);
-            this.emit(EventTypes.MESSAGE, {
-                key: 'combat.damage.dealt',
-                meta: { amount: prevEnemyHealth - enemy.health },
-                sentiment: SentimentTypes.BRUTAL
-            });
-            
-            state.character.receiveDamage(enemy.damage);
-            this.emit(EventTypes.MESSAGE, {
-                key: 'combat.damage.receive',
-                meta: { amount: enemy.damage },
-                sentiment: SentimentTypes.PAIN
-            });
-
-            this.emit(EventTypes.MESSAGE, {
-                key: `combat.hitpoints`,
-                meta: {
-                    amount: state.character.profession.health
-                }
-            });
-        }
-
-        if (state.character.profession.health <= 0) {
-            // We didn't make it...
-            return this.emit(EventTypes.CHARACTER_DEATH, state.character)
-        } else {
-            // We won!
-            this.emit(EventTypes.MESSAGE, {
-                key: "combat.result.enemyDefeated"
-            });
-            
-            this.emit(EventTypes.MESSAGE, {
-                key: "combat.result.loot",
-                meta: { gold },
-                sentiment: SentimentTypes.INFORMATIONAL
-            });
-            
-            state.character.gold += enemy.gold;
-            state.character.gainXP(enemy.xp)
-
-            this.emit(EventTypes.MESSAGE, {
-                key: "combat.result.xp",
-                meta: { xp: enemy.xp },
-                sentiment: SentimentTypes.INFORMATIONAL
-            });
-
-            if(state.character.xp >= state.character.nextLevelAt) {
-                state.character.levelUp();
-            }
-
-            this.emit(EventTypes.MESSAGE, {
-                key: "combat.result.stats",
-                meta: {
-                    health: state.character.profession.health,
-                    gold: state.character.gold,
-                    xp: state.character.xp
-                }
-            });
-        }
-
-        // Emit updated state.
-        this.emit(EventTypes.UPDATE_STATE, state);
-    }
-
-    rest() {
-        // Make a clone of the current state which we'll emit
-        // at the end of the action.
-        const state = Object.assign({}, this.state);
-
-        state.character.gold -= 50;
-        state.character.profession.health += 25;
-    
-        this.emit(EventTypes.MESSAGE, {
-            key: "rest.result.change",
-            meta: {
-                healthGain: 25,
-                goldCost: 10
-            }
-        });
-
-        this.emit(EventTypes.MESSAGE, {
-            key: "rest.result.stats",
-            meta: {
-                health: state.character.profession.health,
-                gold: state.character.gold
-            }
-        });
-
-        // Emit updated state.
-        this.emit(EventTypes.UPDATE_STATE, state);
-    }
-
-    viewCharacter() {
-        this.emit(EventTypes.VIEW_CHARACTER, this.state.character);
-    }
-
-    createCharacter() {
-        // Emit an event asking for answers for these prompts.
-        this.emit(EventTypes.MESSAGE, {
-            key: "welcome.new",
-            sentiment: SentimentTypes.POSITIVE
-        });
-
-        this.emit(EventTypes.PROMPTS, [
-            {
-                key: 'name',
-                type: 'input',
-            },
-            {
-                key: 'profession',
-                type: 'list',
-                choices: ['Warrior', 'Thief', 'Mage']
-            }
-        ]);
-
-        // Listen for the response to come in once.
-        this.once(EventTypes.PROMPT_RESPONSE, ([{ name }, { profession }]) => {
-            this.state = this.state || {};
-            this.state.character = new Character(name, profession);
-            // Emit a clone of the current state with the character updated!
-            this.emit(EventTypes.UPDATE_STATE, Object.assign({}, this.state))
-
-            this.start();
-        });
+    handlePlayerResponse(responses) {
+        gameService.send({ type: EventTypes.PROMPT_RESPONSE, responses });
     }
 }
 
+function createGame(gameState) {
+    if (game) return game;
 
-module.exports = Game;
+    gameState.character = new Character(
+        gameState.character.name,
+        gameState.character.profession.profession,
+        gameState.character.gold,
+        gameState.character.profession.health,
+        gameState.character.attack,
+        gameState.character.level,
+        gameState.character.xp,
+        gameState.character.nextLevelAt
+    );
+
+    game = new Game();
+
+    machine = Machine(
+        {
+            id: 'game',
+            context: {
+                gameState,
+                game,
+            },
+            initial: 'welcome',
+            states: {
+                // Transient state that displays our welcome message
+                // and immediate transitions to the main menu or
+                // the character creation.
+                welcome: {
+                    // Immediate transition this state after our entry/exit actions...
+                    always: [
+                        // If we have a current gameState, then we have a valid character.
+                        { target: 'mainMenu', cond: (context, event) => context.gameState },
+                        // If we don't have a gameState, we need to create a character.
+                        { target: 'createCharacter', cond: (context, event) => !context.gameState }
+                    ],
+                    entry: [
+                        // Send our welcome message when we enter this state.
+                        (context, event) => context.game.emit(EventTypes.MESSAGE, { key: 'game.name' }),
+                    ]
+                },
+                createCharacter: {
+                    // This is a nested state, and we start with the prompt sub-state, so
+                    // that we can send our prompts to the interface and wait for the 
+                    // response.
+                    initial: 'createCharacterPrompt',
+                    states: {
+                        createCharacterPrompt: {
+                            on: {
+                                // Transition when we get a response back from the interface.
+                                [EventTypes.PROMPT_RESPONSE]: 'createCharacterHandleResponse'
+                            },
+                            entry: [
+                                // First send them the welcome message for new characters.
+                                (context, event) => context.game.emit(EventTypes.MESSAGE, {
+                                    key: "welcome.new",
+                                    sentiment: SentimentTypes.POSITIVE
+                                }),
+                                // Then send over the prmopts we need filled.
+                                (context, event) => context.game.emit(EventTypes.PROMPTS, [
+                                    {
+                                        key: 'name',
+                                        type: 'input',
+                                    },
+                                    {
+                                        key: 'profession',
+                                        type: 'list',
+                                        choices: ['Warrior', 'Thief', 'Mage']
+                                    }
+                                ])
+                            ]
+                        },
+                        createCharacterHandleResponse: {
+                            // Once we handle the responses, we can end these sub-states.
+                            type: 'final',
+                            entry: [
+                                // Update the game state with the new character we've created.
+                                assign((context, { responses: [{ name }, { profession }] }) => {
+                                    context.gameState = context.gameState || {};
+                                    context.gameState.character = new Character(name, profession);
+                                    return context;
+                                }),
+                                (context, event) => {
+                                    // Emit a clone of the current state with the character updated!
+                                    context.game.emit(EventTypes.UPDATE_STATE, Object.assign({}, context.gameState))
+                                }
+                            ]
+                        },
+                    },
+                    // When our sub-states are done, we go back to the welcome state.
+                    // Now that we have a character, it'll send us on to the main menu.
+                    onDone: 'welcome'
+                },
+                mainMenu: {
+                    // This is a nested state, and we start it out by prompting the player
+                    // for the action they want to take.
+                    initial: 'mainMenuPrompt',
+                    states: {
+                        mainMenuPrompt: {
+                            // We transition when we get their response.
+                            // We conditionally send them to one of our action states
+                            // depending on the response to the "main" prompt.
+                            on: {
+                                [EventTypes.PROMPT_RESPONSE]: [
+                                    {
+                                        target: 'combat',
+                                        cond: (context, { responses: [{ main }] }) => main === ActionTypes.FIGHT_ENEMY
+                                    },
+                                    {
+                                        target: 'rest',
+                                        cond: (context, { responses: [{ main }] }) => main === ActionTypes.REST
+                                    },
+                                    {
+                                        target: 'viewCharacter',
+                                        cond: (context, { responses: [{ main }] }) => main === ActionTypes.VIEW_CHARACTER
+                                    }
+                                ]
+                            },
+                            entry: [
+                                // Send our main menu prompt to the interface which is the list
+                                // of actions that the player can select from a list.
+                                (context, event) => context.game.emit(EventTypes.PROMPTS, [
+                                    {
+                                        key: 'main',
+                                        type: 'list',
+                                        choices: [
+                                            ActionTypes.FIGHT_ENEMY,
+                                            ActionTypes.REST,
+                                            ActionTypes.VIEW_CHARACTER
+                                        ]
+                                    }
+                                ]),
+                            ]
+                        },
+                        combat: {
+                            // This state is a transient state, it will always transition
+                            // after taking it's entry/exit actions. Since the entry actions
+                            // occur immediately on entering the state, we let the result of
+                            // those alter the game state, and then inside of our "always" possible
+                            // states, we look at the player health, which was changed in the entry
+                            // action which occurred first.
+                            always: [
+                                // As long as we're still alive, take another turn.
+                                {
+                                    target: 'mainMenuPrompt',
+                                    cond: (context, event) => context.gameState.character.profession.health > 0,
+                                },
+                                // If we're after the entry action, go to the death state.
+                                {
+                                    target: 'death',
+                                    cond: (context, event) => context.gameState.character.profession.health <= 0,
+                                }
+                            ],
+                            entry: [
+                                // Run the combat, and update the context gameState. Since we are modifying the
+                                // gameState of the context, we need to use the assign function.
+                                assign((context, event) => {
+                                    const gameState = context.gameState;
+
+                                    // Naive enemy implementation...
+                                    const damage = Math.floor(Math.random() * 10 + 1); // 1 - 10 damage
+                                    const health = Math.floor(Math.random() * 10 + 21); // 10 - 30 health
+                                    const gold = health + damage;
+                                    const xp = health;
+        
+                                    const enemy = { damage, health, gold, xp };
+
+
+                                    while (gameState.character.profession.health > 0 && enemy.health > 0) {
+                                        const prevEnemyHealth = enemy.health;
+
+                                        enemy.health -= gameState.character.profession.attack;
+                                        context.game.emit(EventTypes.MESSAGE, {
+                                            key: 'combat.damage.dealt',
+                                            meta: { amount: prevEnemyHealth - enemy.health },
+                                            sentiment: SentimentTypes.BRUTAL
+                                        });
+
+                                        gameState.character.profession.health -= enemy.damage;
+                                        context.game.emit(EventTypes.MESSAGE, {
+                                            key: 'combat.damage.receive',
+                                            meta: { amount: enemy.damage },
+                                            sentiment: SentimentTypes.PAIN
+                                        });
+
+                                        context.game.emit(EventTypes.MESSAGE, {
+                                            key: `combat.hitpoints`,
+                                            meta: {
+                                                amount: gameState.character.profession.health
+                                            }
+                                        });
+                                    }
+
+                                    if (gameState.character.profession.health <= 0) {
+                                        // We didn't make it...
+                                        // Always return the context inside of an 'assign' call
+                                        return context;
+                                    } else {
+                                        // We won!
+                                        context.game.emit(EventTypes.MESSAGE, {
+                                            key: "combat.result.enemyDefeated"
+                                        });
+
+                                        context.game.emit(EventTypes.MESSAGE, {
+                                            key: "combat.result.loot",
+                                            meta: { gold },
+                                            sentiment: SentimentTypes.INFORMATIONAL
+                                        });
+
+                                        gameState.character.gold += enemy.gold;
+                                        gameState.character.gainXP(enemy.xp)
+
+                                        context.game.emit(EventTypes.MESSAGE, {
+                                            key: "combat.result.xp",
+                                            meta: { xp: enemy.xp },
+                                            sentiment: SentimentTypes.INFORMATIONAL
+                                        });
+                            
+                                        if(gameState.character.xp >= gameState.character.nextLevelAt) {
+                                            gameState.character.levelUp();
+
+                                            context.game.emit(EventTypes.MESSAGE, {
+                                                key: "character.level",
+                                                meta: {
+                                                    level: gameState.character.level,
+                                                    health: gameState.character.profession.health,
+                                                    attack: gameState.character.profession.attack
+                                                },
+                                                sentiment: SentimentTypes.INFORMATIONAL
+                                            });
+
+                                            context.game.emit(EventTypes.MESSAGE, {
+                                                key: "character.level.next",
+                                                meta: { nextLevelAt: gameState.character.nextLevelAt },
+                                                sentiment: SentimentTypes.INFORMATIONAL
+                                            });
+                                        }
+
+                                        context.game.emit(EventTypes.MESSAGE, {
+                                            key: "combat.result.stats",
+                                            meta: {
+                                                health: gameState.character.profession.health,
+                                                gold: gameState.character.gold,
+                                                xp: gameState.character.xp
+                                            }
+                                        });
+                                    }
+                                    // Always return the context inside of an 'assign' call.
+                                    return context;
+                                }),
+                                    // Emit a clone of the current state after combat
+                                (context, event) =>
+                                    context.game.emit(EventTypes.UPDATE_STATE, Object.assign({}, context.gameState))
+                                
+                            ]
+                        },
+                        rest: {
+                            // After resting, always return to the main menu.
+                            // This is a transient state, we just modify the gameState in the
+                            // entry action and send out messages to the interface.
+                            always: 'mainMenuPrompt',
+                            entry: [
+                                // Update the gameState with our rested character
+                                // Since we're updating the context, we wrap with 'assign' call
+                                assign((context, event) => {
+                                    gameState = Object.assign({}, context.gameState);
+
+                                    gameState.character.gold -= 50;
+                                    gameState.character.profession.health += 25;
+
+                                    context.game.emit(EventTypes.MESSAGE, {
+                                        key: "rest.result.change",
+                                        meta: {
+                                            healthGain: 25,
+                                            goldCost: 10
+                                        }
+                                    });
+
+                                    context.game.emit(EventTypes.MESSAGE, {
+                                        key: "rest.result.stats",
+                                        meta: {
+                                            health: gameState.character.profession.health,
+                                            gold: gameState.character.gold
+                                        }
+                                    });
+
+                                    return context;
+                                }),
+                                // Emit a clone of the current state after resting
+                                (context, event) =>
+                                    context.game.emit(EventTypes.UPDATE_STATE, Object.assign({}, context.gameState))
+                            ]
+                        },
+                        viewCharacter: {
+                            // Always go back to the main menu afterwards
+                            // Should view character be a prompt type?
+                            // This is a really simple transient state that send the view character
+                            // event to the interface and immediately transition to the main menu.
+                            always: 'mainMenuPrompt',
+                            entry: [
+                                (context, event) => context.game.emit(EventTypes.VIEW_CHARACTER, context.gameState.character)
+                            ]
+                        },
+                        // A final state of our main menu nested state. When we enter this state we emit
+                        // the character death event.
+                        death: {
+                            type: 'final',
+                            entry: [
+                                (context, event) => context.game.emit(EventTypes.CHARACTER_DEATH, context.gameState.character),
+                            ]
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    return game;
+}
+
+module.exports = createGame;

--- a/Game.js
+++ b/Game.js
@@ -196,7 +196,6 @@ class Game extends events.EventEmitter {
                 choices: ['Warrior', 'Thief', 'Mage']
             }
         ]);
-
         // Listen for the response to come in once.
         this.once(EventTypes.PROMPT_RESPONSE, ([{ name }, { profession }]) => {
             this.state = this.state || {};

--- a/Game.js
+++ b/Game.js
@@ -196,6 +196,7 @@ class Game extends events.EventEmitter {
                 choices: ['Warrior', 'Thief', 'Mage']
             }
         ]);
+
         // Listen for the response to come in once.
         this.once(EventTypes.PROMPT_RESPONSE, ([{ name }, { profession }]) => {
             this.state = this.state || {};

--- a/index.html
+++ b/index.html
@@ -48,6 +48,14 @@
                 ({ name }) => `Welcome back, ${name}`
             ],
             [
+                "character.level",
+                ({ level, health, attack }) => `You are now level ${level}! You now have ${health} health and ${attack} attack.`
+            ],
+            [
+                "character.level.next",
+                ({ nextLevelAt }) => `Reach the next level at ${nextLevelAt} XP!`
+            ],
+            [
                 "combat.damage.dealt",
                 ({ amount }) => `You hit the enemy for ${amount} damage.`
             ],
@@ -72,8 +80,12 @@
                 ({ gold }) => `You have received ${gold} gold!`
             ],
             [
+                "combat.result.xp",
+                ({ xp }) => `You gained ${xp} XP!`
+            ],
+            [
                 "combat.result.stats",
-                ({ health, gold }) => `You now have ${health} health and ${gold} gold.`
+                ({ health, gold, xp }) => `You now have ${health} health and ${gold} gold and ${xp} XP.`
             ],
             [
                 "rest.result.change",

--- a/index.js
+++ b/index.js
@@ -16,53 +16,41 @@ if (process.argv[2] === "cli") {
     interface = new ElectronInterface();
 }
 const state = new FileSystemState();
-const game = new Game();
-
-game.on(EventTypes.PROMPTS, (prompts) => {
-    // When the game needs prompts, prompt the player.
-    interface.promptPlayer(prompts)
-    // And then listen for the response from the interface, and emit it back
-    // to the game, which is listening to itself for a single response.
-    interface.once(
-        EventTypes.PROMPT_RESPONSE,
-        (responses) => game.emit(EventTypes.PROMPT_RESPONSE, responses)
-    );
-});
-
-// When the game updates the state, we save it.
-game.on(EventTypes.UPDATE_STATE, (newState) => state.write(newState));
-
-// When a message from the game comes in, ask the interface to handle it.
-game.on(EventTypes.MESSAGE, (message) => interface.handleMessage(message));
-
-// When the player want's to view their character, ask the interface to do it.
-game.on(EventTypes.VIEW_CHARACTER, (character) => interface.viewCharacter(character));
-
-// When the character has died. View their character one last time, and then delete the save.
-game.on(EventTypes.CHARACTER_DEATH, (character) => {
-    interface.handleDeath(character);
-    // If there is an error, console error it.
-    state.del(err => { if (err) console.error(err) });
-})
-
-// Initial state load we want to start the game, when the state updates
-// after that we just want to update the game and interface
-state.once(EventTypes.STATE_UPDATED, (newState) => {
-    game.setState(newState);
-
-    // Set up a listener for the rest of the state updates after the
-    // first time the save loads.
-    state.on(EventTypes.STATE_UPDATED, (newState) => {
-        game.setState(newState);
-    });
-
-    process.nextTick(() => {
-        game.start();
-    })
-})
-
 
 // Load the save file.
 interface.on(EventTypes.INTERFACE_READY, () => {
-    state.read();
+    state.read().then(data => {
+        const game = Game(data);
+
+        game.on(EventTypes.PROMPTS, (prompts) => {
+            // When the game needs prompts, prompt the player.
+            interface.promptPlayer(prompts)
+            // And then listen for the response from the interface, and emit it back
+            // to the game, which is listening to itself for a single response.
+            interface.once(
+                EventTypes.PROMPT_RESPONSE,
+                (responses) => game.handlePlayerResponse(responses)
+            );
+        });
+        
+        // When the game updates the state, we save it.
+        game.on(EventTypes.UPDATE_STATE, (newState) => state.write(newState));
+        
+        // When a message from the game comes in, ask the interface to handle it.
+        game.on(EventTypes.MESSAGE, (message) => interface.handleMessage(message));
+        
+        // When the player want's to view their character, ask the interface to do it.
+        game.on(EventTypes.VIEW_CHARACTER, (character) => interface.viewCharacter(character));
+        
+        // When the character has died. View their character one last time, and then delete the save.
+        game.on(EventTypes.CHARACTER_DEATH, (character) => {
+            interface.handleDeath(character);
+            // If there is an error, console error it.
+            state.del(err => { if (err) console.error(err) });
+        });
+
+        process.nextTick(() => {
+            game.start();
+        })
+    });
 });

--- a/interface.js
+++ b/interface.js
@@ -25,6 +25,14 @@ const messageMap = new Map([
         ({ name }) => `Welcome back, ${name}`
     ],
     [
+        "character.level",
+        ({ level, health, attack }) => `You are now level ${level}! You now have ${health} health and ${attack} attack.`
+    ],
+    [
+        "character.level.next",
+        ({ nextLevelAt }) => `Reach the next level at ${nextLevelAt} XP!`
+    ],
+    [
         "combat.damage.dealt",
         ({ amount }) => `You hit the enemy for ${amount} damage.`
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5224,6 +5224,11 @@
       "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
       "dev": true
     },
+    "xstate": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.15.2.tgz",
+      "integrity": "sha512-C+3jzJbhkp9ywGB+E2YMbS4mLyuxv366+KGi2RBX6y99xZFezbrGfaPQGRvFvn58OlLlCuSfCwn6bPcp78aMyw=="
+    },
     "xtend": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "electron-squirrel-startup": "^1.0.0",
-    "inquirer": "^7.3.3"
+    "inquirer": "^7.3.3",
+    "xstate": "^4.15.2"
   },
   "devDependencies": {
     "@electron-forge/cli": "^6.0.0-beta.54",


### PR DESCRIPTION
In order to set the game up to grow rapidly, we need a way
to represent the flow of the game as a graph of logical states.
This adds the XState library for state machines. The main game
logic is implemented as a single machine, and communication with
the interface happens the same as before, through events emitted
from the game event emitter. The events are emitted as either
entry or exit actions during state transitions.